### PR TITLE
Array buffer being undefined threw exception in older browsers. 

### DIFF
--- a/xxhash.js
+++ b/xxhash.js
@@ -155,7 +155,7 @@
 			isArrayBuffer = true
 		}
 
-		if (input instanceof ArrayBuffer)
+		if (typeof ArrayBuffer !== "undefined" && input instanceof ArrayBuffer)
 		{
 			isArrayBuffer = true
 			input = new Uint8Array(input);


### PR DESCRIPTION
Added check to see if it was undefined