### PR TITLE
Remove benchmark from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+benchmark/


### PR DESCRIPTION
1MB of unnecessary bulk not needed outside of development.