### PR TITLE
Update cuint dependency to specify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/pierrec/js-xxhash"
 , "dependencies": {
-    "cuint": "latest"
+    "cuint": "^1.0.1"
   }
 , "devDependencies": {
     "webpack": "*"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/pierrec/js-xxhash"
 , "dependencies": {
-    "cuint": "^1.0.1"
+    "cuint": "^0.2.2"
   }
 , "devDependencies": {
     "webpack": "*"


### PR DESCRIPTION
Using `latest` seems to have been causing issues in our projects when generating shrinkwraps. The community standard is to specify a version anyway, so this seems reasonable.