### PR TITLE
Remove redundant isString checks

### DIFF
--- a/lib/xxhash.js
+++ b/lib/xxhash.js
@@ -141,13 +141,11 @@ XXH.prototype.init = init
  * @return ThisExpression
  */
 XXH.prototype.update = function (input) {
-	var isString = typeof input == 'string'
 	var isArrayBuffer
 
 	// Convert all strings to utf-8 first (issue #5)
-	if (isString) {
+	if (typeof input == 'string') {
 		input = toUTF8Array(input)
-		isString = false
 		isArrayBuffer = true
 	}
 
@@ -167,9 +165,7 @@ XXH.prototype.update = function (input) {
 
 	if (this.memsize == 0)
 	{
-		if (isString) {
-			this.memory = ''
-		} else if (isArrayBuffer) {
+		if (isArrayBuffer) {
 			this.memory = new Uint8Array(16)
 		} else {
 			this.memory = new Buffer(16)
@@ -179,9 +175,7 @@ XXH.prototype.update = function (input) {
 	if (this.memsize + len < 16)   // fill in tmp buffer
 	{
 		// XXH_memcpy(this.memory + this.memsize, input, len)
-		if (isString) {
-			this.memory += input
-		} else if (isArrayBuffer) {
+		if (isArrayBuffer) {
 			this.memory.set( input.subarray(0, len), this.memsize )
 		} else {
 			input.copy( this.memory, this.memsize, 0, len )
@@ -194,60 +188,35 @@ XXH.prototype.update = function (input) {
 	if (this.memsize > 0)   // some data left from previous update
 	{
 		// XXH_memcpy(this.memory + this.memsize, input, 16-this.memsize);
-		if (isString) {
-			this.memory += input.slice(0, 16 - this.memsize)
-		} else if (isArrayBuffer) {
+		if (isArrayBuffer) {
 			this.memory.set( input.subarray(0, 16 - this.memsize), this.memsize )
 		} else {
 			input.copy( this.memory, this.memsize, 0, 16 - this.memsize )
 		}
 
 		var p32 = 0
-		if (isString) {
-			this.v1.xxh_update(
-				(this.memory.charCodeAt(p32+1) << 8) | this.memory.charCodeAt(p32)
-			,	(this.memory.charCodeAt(p32+3) << 8) | this.memory.charCodeAt(p32+2)
-			)
-			p32 += 4
-			this.v2.xxh_update(
-				(this.memory.charCodeAt(p32+1) << 8) | this.memory.charCodeAt(p32)
-			,	(this.memory.charCodeAt(p32+3) << 8) | this.memory.charCodeAt(p32+2)
-			)
-			p32 += 4
-			this.v3.xxh_update(
-				(this.memory.charCodeAt(p32+1) << 8) | this.memory.charCodeAt(p32)
-			,	(this.memory.charCodeAt(p32+3) << 8) | this.memory.charCodeAt(p32+2)
-			)
-			p32 += 4
-			this.v4.xxh_update(
-				(this.memory.charCodeAt(p32+1) << 8) | this.memory.charCodeAt(p32)
-			,	(this.memory.charCodeAt(p32+3) << 8) | this.memory.charCodeAt(p32+2)
-			)
-		} else {
-			this.v1.xxh_update(
-				(this.memory[p32+1] << 8) | this.memory[p32]
-			,	(this.memory[p32+3] << 8) | this.memory[p32+2]
-			)
-			p32 += 4
-			this.v2.xxh_update(
-				(this.memory[p32+1] << 8) | this.memory[p32]
-			,	(this.memory[p32+3] << 8) | this.memory[p32+2]
-			)
-			p32 += 4
-			this.v3.xxh_update(
-				(this.memory[p32+1] << 8) | this.memory[p32]
-			,	(this.memory[p32+3] << 8) | this.memory[p32+2]
-			)
-			p32 += 4
-			this.v4.xxh_update(
-				(this.memory[p32+1] << 8) | this.memory[p32]
-			,	(this.memory[p32+3] << 8) | this.memory[p32+2]
-			)
-		}
+		this.v1.xxh_update(
+			(this.memory[p32+1] << 8) | this.memory[p32]
+		,	(this.memory[p32+3] << 8) | this.memory[p32+2]
+		)
+		p32 += 4
+		this.v2.xxh_update(
+			(this.memory[p32+1] << 8) | this.memory[p32]
+		,	(this.memory[p32+3] << 8) | this.memory[p32+2]
+		)
+		p32 += 4
+		this.v3.xxh_update(
+			(this.memory[p32+1] << 8) | this.memory[p32]
+		,	(this.memory[p32+3] << 8) | this.memory[p32+2]
+		)
+		p32 += 4
+		this.v4.xxh_update(
+			(this.memory[p32+1] << 8) | this.memory[p32]
+		,	(this.memory[p32+3] << 8) | this.memory[p32+2]
+		)
 
 		p += 16 - this.memsize
 		this.memsize = 0
-		if (isString) this.memory = ''
 	}
 
 	if (p <= bEnd - 16)
@@ -256,47 +225,25 @@ XXH.prototype.update = function (input) {
 
 		do
 		{
-			if (isString) {
-				this.v1.xxh_update(
-					(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-				,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-				)
-				p += 4
-				this.v2.xxh_update(
-					(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-				,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-				)
-				p += 4
-				this.v3.xxh_update(
-					(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-				,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-				)
-				p += 4
-				this.v4.xxh_update(
-					(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-				,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-				)
-			} else {
-				this.v1.xxh_update(
-					(input[p+1] << 8) | input[p]
-				,	(input[p+3] << 8) | input[p+2]
-				)
-				p += 4
-				this.v2.xxh_update(
-					(input[p+1] << 8) | input[p]
-				,	(input[p+3] << 8) | input[p+2]
-				)
-				p += 4
-				this.v3.xxh_update(
-					(input[p+1] << 8) | input[p]
-				,	(input[p+3] << 8) | input[p+2]
-				)
-				p += 4
-				this.v4.xxh_update(
-					(input[p+1] << 8) | input[p]
-				,	(input[p+3] << 8) | input[p+2]
-				)
-			}
+			this.v1.xxh_update(
+				(input[p+1] << 8) | input[p]
+			,	(input[p+3] << 8) | input[p+2]
+			)
+			p += 4
+			this.v2.xxh_update(
+				(input[p+1] << 8) | input[p]
+			,	(input[p+3] << 8) | input[p+2]
+			)
+			p += 4
+			this.v3.xxh_update(
+				(input[p+1] << 8) | input[p]
+			,	(input[p+3] << 8) | input[p+2]
+			)
+			p += 4
+			this.v4.xxh_update(
+				(input[p+1] << 8) | input[p]
+			,	(input[p+3] << 8) | input[p+2]
+			)
 			p += 4
 		} while (p <= limit)
 	}
@@ -304,9 +251,7 @@ XXH.prototype.update = function (input) {
 	if (p < bEnd)
 	{
 		// XXH_memcpy(this.memory, p, bEnd-p);
-		if (isString) {
-			this.memory += input.slice(p)
-		} else if (isArrayBuffer) {
+		if (isArrayBuffer) {
 			this.memory.set( input.subarray(p, bEnd), this.memsize )
 		} else {
 			input.copy( this.memory, this.memsize, p, bEnd )
@@ -325,7 +270,6 @@ XXH.prototype.update = function (input) {
  */
 XXH.prototype.digest = function () {
 	var input = this.memory
-	var isString = typeof input == 'string'
 	var p = 0
 	var bEnd = this.memsize
 	var h32, h
@@ -344,17 +288,10 @@ XXH.prototype.digest = function () {
 
 	while (p <= bEnd - 4)
 	{
-		if (isString) {
-			u.fromBits(
-				(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-			,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-			)
-		} else {
-			u.fromBits(
-				(input[p+1] << 8) | input[p]
-			,	(input[p+3] << 8) | input[p+2]
-			)
-		}
+		u.fromBits(
+			(input[p+1] << 8) | input[p]
+		,	(input[p+3] << 8) | input[p+2]
+		)
 		h32
 			.add( u.multiply(PRIME32_3) )
 			.rotl(17)
@@ -364,7 +301,7 @@ XXH.prototype.digest = function () {
 
 	while (p < bEnd)
 	{
-		u.fromBits( isString ? input.charCodeAt(p++) : input[p++], 0 )
+		u.fromBits( input[p++], 0 )
 		h32
 			.add( u.multiply(PRIME32_5) )
 			.rotl(11)

--- a/lib/xxhash64.js
+++ b/lib/xxhash64.js
@@ -99,13 +99,11 @@ XXH64.prototype.init = init
  * @return ThisExpression
  */
 XXH64.prototype.update = function (input) {
-	var isString = typeof input == 'string'
 	var isArrayBuffer
 
 	// Convert all strings to utf-8 first (issue #5)
-	if (isString) {
+	if (typeof input == 'string') {
 		input = toUTF8Array(input)
-		isString = false
 		isArrayBuffer = true
 	}
 
@@ -125,9 +123,7 @@ XXH64.prototype.update = function (input) {
 
 	if (this.memsize == 0)
 	{
-		if (isString) {
-			this.memory = ''
-		} else if (isArrayBuffer) {
+		if (isArrayBuffer) {
 			this.memory = new Uint8Array(32)
 		} else {
 			this.memory = new Buffer(32)
@@ -137,9 +133,7 @@ XXH64.prototype.update = function (input) {
 	if (this.memsize + len < 32)   // fill in tmp buffer
 	{
 		// XXH64_memcpy(this.memory + this.memsize, input, len)
-		if (isString) {
-			this.memory += input
-		} else if (isArrayBuffer) {
+		if (isArrayBuffer) {
 			this.memory.set( input.subarray(0, len), this.memsize )
 		} else {
 			input.copy( this.memory, this.memsize, 0, len )
@@ -152,86 +146,48 @@ XXH64.prototype.update = function (input) {
 	if (this.memsize > 0)   // some data left from previous update
 	{
 		// XXH64_memcpy(this.memory + this.memsize, input, 16-this.memsize);
-		if (isString) {
-			this.memory += input.slice(0, 32 - this.memsize)
-		} else if (isArrayBuffer) {
+		if (isArrayBuffer) {
 			this.memory.set( input.subarray(0, 32 - this.memsize), this.memsize )
 		} else {
 			input.copy( this.memory, this.memsize, 0, 32 - this.memsize )
 		}
 
 		var p64 = 0
-		if (isString) {
-			var other
-			other = UINT64(
-					(this.memory.charCodeAt(p64+1) << 8) | this.memory.charCodeAt(p64)
-				,	(this.memory.charCodeAt(p64+3) << 8) | this.memory.charCodeAt(p64+2)
-				,	(this.memory.charCodeAt(p64+5) << 8) | this.memory.charCodeAt(p64+4)
-				,	(this.memory.charCodeAt(p64+7) << 8) | this.memory.charCodeAt(p64+6)
-				)
-			this.v1.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-			p64 += 8
-			other = UINT64(
-					(this.memory.charCodeAt(p64+1) << 8) | this.memory.charCodeAt(p64)
-				,	(this.memory.charCodeAt(p64+3) << 8) | this.memory.charCodeAt(p64+2)
-				,	(this.memory.charCodeAt(p64+5) << 8) | this.memory.charCodeAt(p64+4)
-				,	(this.memory.charCodeAt(p64+7) << 8) | this.memory.charCodeAt(p64+6)
-				)
-			this.v2.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-			p64 += 8
-			other = UINT64(
-					(this.memory.charCodeAt(p64+1) << 8) | this.memory.charCodeAt(p64)
-				,	(this.memory.charCodeAt(p64+3) << 8) | this.memory.charCodeAt(p64+2)
-				,	(this.memory.charCodeAt(p64+5) << 8) | this.memory.charCodeAt(p64+4)
-				,	(this.memory.charCodeAt(p64+7) << 8) | this.memory.charCodeAt(p64+6)
-				)
-			this.v3.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-			p64 += 8
-			other = UINT64(
-					(this.memory.charCodeAt(p64+1) << 8) | this.memory.charCodeAt(p64)
-				,	(this.memory.charCodeAt(p64+3) << 8) | this.memory.charCodeAt(p64+2)
-				,	(this.memory.charCodeAt(p64+5) << 8) | this.memory.charCodeAt(p64+4)
-				,	(this.memory.charCodeAt(p64+7) << 8) | this.memory.charCodeAt(p64+6)
-				)
-			this.v4.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-		} else {
-			var other
-			other = UINT64(
-					(this.memory[p64+1] << 8) | this.memory[p64]
-				,	(this.memory[p64+3] << 8) | this.memory[p64+2]
-				,	(this.memory[p64+5] << 8) | this.memory[p64+4]
-				,	(this.memory[p64+7] << 8) | this.memory[p64+6]
-				)
-			this.v1.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-			p64 += 8
-			other = UINT64(
-					(this.memory[p64+1] << 8) | this.memory[p64]
-				,	(this.memory[p64+3] << 8) | this.memory[p64+2]
-				,	(this.memory[p64+5] << 8) | this.memory[p64+4]
-				,	(this.memory[p64+7] << 8) | this.memory[p64+6]
-				)
-			this.v2.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-			p64 += 8
-			other = UINT64(
-					(this.memory[p64+1] << 8) | this.memory[p64]
-				,	(this.memory[p64+3] << 8) | this.memory[p64+2]
-				,	(this.memory[p64+5] << 8) | this.memory[p64+4]
-				,	(this.memory[p64+7] << 8) | this.memory[p64+6]
-				)
-			this.v3.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-			p64 += 8
-			other = UINT64(
-					(this.memory[p64+1] << 8) | this.memory[p64]
-				,	(this.memory[p64+3] << 8) | this.memory[p64+2]
-				,	(this.memory[p64+5] << 8) | this.memory[p64+4]
-				,	(this.memory[p64+7] << 8) | this.memory[p64+6]
-				)
-			this.v4.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-		}
+		var other
+		other = UINT64(
+				(this.memory[p64+1] << 8) | this.memory[p64]
+			,	(this.memory[p64+3] << 8) | this.memory[p64+2]
+			,	(this.memory[p64+5] << 8) | this.memory[p64+4]
+			,	(this.memory[p64+7] << 8) | this.memory[p64+6]
+			)
+		this.v1.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
+		p64 += 8
+		other = UINT64(
+				(this.memory[p64+1] << 8) | this.memory[p64]
+			,	(this.memory[p64+3] << 8) | this.memory[p64+2]
+			,	(this.memory[p64+5] << 8) | this.memory[p64+4]
+			,	(this.memory[p64+7] << 8) | this.memory[p64+6]
+			)
+		this.v2.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
+		p64 += 8
+		other = UINT64(
+				(this.memory[p64+1] << 8) | this.memory[p64]
+			,	(this.memory[p64+3] << 8) | this.memory[p64+2]
+			,	(this.memory[p64+5] << 8) | this.memory[p64+4]
+			,	(this.memory[p64+7] << 8) | this.memory[p64+6]
+			)
+		this.v3.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
+		p64 += 8
+		other = UINT64(
+				(this.memory[p64+1] << 8) | this.memory[p64]
+			,	(this.memory[p64+3] << 8) | this.memory[p64+2]
+			,	(this.memory[p64+5] << 8) | this.memory[p64+4]
+			,	(this.memory[p64+7] << 8) | this.memory[p64+6]
+			)
+		this.v4.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
 
 		p += 32 - this.memsize
 		this.memsize = 0
-		if (isString) this.memory = ''
 	}
 
 	if (p <= bEnd - 32)
@@ -240,73 +196,38 @@ XXH64.prototype.update = function (input) {
 
 		do
 		{
-			if (isString) {
-				var other
-				other = UINT64(
-						(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-					,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-					,	(input.charCodeAt(p+5) << 8) | input.charCodeAt(p+4)
-					,	(input.charCodeAt(p+7) << 8) | input.charCodeAt(p+6)
-					)
-				this.v1.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-				p += 8
-				other = UINT64(
-						(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-					,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-					,	(input.charCodeAt(p+5) << 8) | input.charCodeAt(p+4)
-					,	(input.charCodeAt(p+7) << 8) | input.charCodeAt(p+6)
-					)
-				this.v2.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-				p += 8
-				other = UINT64(
-						(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-					,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-					,	(input.charCodeAt(p+5) << 8) | input.charCodeAt(p+4)
-					,	(input.charCodeAt(p+7) << 8) | input.charCodeAt(p+6)
-					)
-				this.v3.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-				p += 8
-				other = UINT64(
-						(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-					,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-					,	(input.charCodeAt(p+5) << 8) | input.charCodeAt(p+4)
-					,	(input.charCodeAt(p+7) << 8) | input.charCodeAt(p+6)
-					)
-				this.v4.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-			} else {
-				var other
-				other = UINT64(
-						(input[p+1] << 8) | input[p]
-					,	(input[p+3] << 8) | input[p+2]
-					,	(input[p+5] << 8) | input[p+4]
-					,	(input[p+7] << 8) | input[p+6]
-					)
-				this.v1.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-				p += 8
-				other = UINT64(
-						(input[p+1] << 8) | input[p]
-					,	(input[p+3] << 8) | input[p+2]
-					,	(input[p+5] << 8) | input[p+4]
-					,	(input[p+7] << 8) | input[p+6]
-					)
-				this.v2.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-				p += 8
-				other = UINT64(
-						(input[p+1] << 8) | input[p]
-					,	(input[p+3] << 8) | input[p+2]
-					,	(input[p+5] << 8) | input[p+4]
-					,	(input[p+7] << 8) | input[p+6]
-					)
-				this.v3.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-				p += 8
-				other = UINT64(
-						(input[p+1] << 8) | input[p]
-					,	(input[p+3] << 8) | input[p+2]
-					,	(input[p+5] << 8) | input[p+4]
-					,	(input[p+7] << 8) | input[p+6]
-					)
-				this.v4.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
-			}
+			var other
+			other = UINT64(
+					(input[p+1] << 8) | input[p]
+				,	(input[p+3] << 8) | input[p+2]
+				,	(input[p+5] << 8) | input[p+4]
+				,	(input[p+7] << 8) | input[p+6]
+				)
+			this.v1.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
+			p += 8
+			other = UINT64(
+					(input[p+1] << 8) | input[p]
+				,	(input[p+3] << 8) | input[p+2]
+				,	(input[p+5] << 8) | input[p+4]
+				,	(input[p+7] << 8) | input[p+6]
+				)
+			this.v2.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
+			p += 8
+			other = UINT64(
+					(input[p+1] << 8) | input[p]
+				,	(input[p+3] << 8) | input[p+2]
+				,	(input[p+5] << 8) | input[p+4]
+				,	(input[p+7] << 8) | input[p+6]
+				)
+			this.v3.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
+			p += 8
+			other = UINT64(
+					(input[p+1] << 8) | input[p]
+				,	(input[p+3] << 8) | input[p+2]
+				,	(input[p+5] << 8) | input[p+4]
+				,	(input[p+7] << 8) | input[p+6]
+				)
+			this.v4.add( other.multiply(PRIME64_2) ).rotl(31).multiply(PRIME64_1);
 			p += 8
 		} while (p <= limit)
 	}
@@ -314,9 +235,7 @@ XXH64.prototype.update = function (input) {
 	if (p < bEnd)
 	{
 		// XXH64_memcpy(this.memory, p, bEnd-p);
-		if (isString) {
-			this.memory += input.slice(p)
-		} else if (isArrayBuffer) {
+		if (isArrayBuffer) {
 			this.memory.set( input.subarray(p, bEnd), this.memsize )
 		} else {
 			input.copy( this.memory, this.memsize, p, bEnd )
@@ -335,7 +254,6 @@ XXH64.prototype.update = function (input) {
  */
 XXH64.prototype.digest = function () {
 	var input = this.memory
-	var isString = typeof input == 'string'
 	var p = 0
 	var bEnd = this.memsize
 	var h64, h
@@ -369,21 +287,12 @@ XXH64.prototype.digest = function () {
 
 	while (p <= bEnd - 8)
 	{
-		if (isString) {
-			u.fromBits(
-				(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-			,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-			,	(input.charCodeAt(p+5) << 8) | input.charCodeAt(p+4)
-			,	(input.charCodeAt(p+7) << 8) | input.charCodeAt(p+6)
+		u.fromBits(
+			(input[p+1] << 8) | input[p]
+		,	(input[p+3] << 8) | input[p+2]
+		,	(input[p+5] << 8) | input[p+4]
+		,	(input[p+7] << 8) | input[p+6]
 			)
-		} else {
-			u.fromBits(
-				(input[p+1] << 8) | input[p]
-			,	(input[p+3] << 8) | input[p+2]
-			,	(input[p+5] << 8) | input[p+4]
-			,	(input[p+7] << 8) | input[p+6]
-			)
-		}
 		u.multiply(PRIME64_2).rotl(31).multiply(PRIME64_1)
 		h64
 			.xor(u)
@@ -394,21 +303,12 @@ XXH64.prototype.digest = function () {
 	}
 
 	if (p + 4 <= bEnd) {
-		if (isString) {
-			u.fromBits(
-				(input.charCodeAt(p+1) << 8) | input.charCodeAt(p)
-			,	(input.charCodeAt(p+3) << 8) | input.charCodeAt(p+2)
-			,	0
-			,	0
-			)
-		} else {
-			u.fromBits(
-				(input[p+1] << 8) | input[p]
-			,	(input[p+3] << 8) | input[p+2]
-			,	0
-			,	0
-			)
-		}
+		u.fromBits(
+			(input[p+1] << 8) | input[p]
+		,	(input[p+3] << 8) | input[p+2]
+		,	0
+		,	0
+		)
 		h64
 			.xor( u.multiply(PRIME64_1) )
 			.rotl(23)
@@ -419,7 +319,7 @@ XXH64.prototype.digest = function () {
 
 	while (p < bEnd)
 	{
-		u.fromBits( isString ? input.charCodeAt(p++) : input[p++], 0, 0, 0 )
+		u.fromBits( input[p++], 0, 0, 0 )
 		h64
 			.xor( u.multiply(PRIME64_5) )
 			.rotl(11)


### PR DESCRIPTION
Strings are converted to UTF-8 byte arrays now, so all the isString checks are dead code that will never be executed.